### PR TITLE
Disable duplicate name validation on new schemas

### DIFF
--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -1238,7 +1238,6 @@ pub fn project(
                 .push(columnize_expr(normalize_col(e, &plan)?, input_schema)),
         }
     }
-    validate_unique_names("Projections", projected_expr.iter())?;
     let input_schema = DFSchema::new_with_metadata(
         exprlist_to_fields(&projected_expr, &plan)?,
         plan.schema().metadata().clone(),


### PR DESCRIPTION
This is a necessary patch for us to handle duplicate names in SELECT statements (e.g. `SELECT x, x from main`). It disables DF's duplicate name validation when creating projections/new schemas, which are non-SQL conformant.

This is a self-contained change -- I will clean this up and try to get it upstreamed.