### PR TITLE
Fix field name of CAST expressions

### DIFF
--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -274,6 +274,26 @@ impl ExprSchemable for Expr {
                 self.get_type(input_schema)?,
                 self.nullable(input_schema)?,
             )),
+            Expr::Cast(Cast { expr, data_type }) => {
+                // CAST does not change the expression name
+                let inner_field = expr.to_field(input_schema)?;
+                Ok(DFField::new(
+                    inner_field.qualifier().map(|x| x.to_owned_reference()),
+                    inner_field.name(),
+                    data_type.clone(),
+                    self.nullable(input_schema)?,
+                ))
+            }
+            Expr::TryCast(TryCast { expr, data_type }) => {
+                // CAST does not change the expression name
+                let inner_field = expr.to_field(input_schema)?;
+                Ok(DFField::new(
+                    inner_field.qualifier().map(|x| x.to_owned_reference()),
+                    inner_field.name(),
+                    data_type.clone(),
+                    self.nullable(input_schema)?,
+                ))
+            }
             _ => Ok(DFField::new_unqualified(
                 &self.display_name()?,
                 self.get_type(input_schema)?,

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -1085,6 +1085,8 @@ pub fn expr_as_column_expr(expr: &Expr, plan: &LogicalPlan) -> Result<Expr> {
             let field = plan.schema().field_from_column(col)?;
             Ok(Expr::Column(field.qualified_column()))
         }
+        Expr::Cast(cast) => expr_as_column_expr(&cast.expr, plan),
+        Expr::TryCast(cast) => expr_as_column_expr(&cast.expr, plan),
         _ => Ok(Expr::Column(Column::from_name(expr.display_name()?))),
     }
 }

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -60,11 +60,7 @@ pub fn resolve_columns(expr: &Expr, plan: &LogicalPlan) -> Result<Expr> {
 /// where post-aggregation, `a + b` need not be a projection against the
 /// individual columns `a` and `b`, but rather it is a projection against the
 /// `a + b` found in the GROUP BY.
-pub fn rebase_expr(
-    expr: &Expr,
-    base_exprs: &[Expr],
-    plan: &LogicalPlan,
-) -> Result<Expr> {
+pub fn rebase_expr(expr: &Expr, base_exprs: &[Expr], plan: &LogicalPlan) -> Result<Expr> {
     clone_with_replacement(expr, &|nested_expr| {
         if base_exprs.contains(nested_expr) {
             Ok(Some(expr_as_column_expr(nested_expr, plan)?))
@@ -509,10 +505,7 @@ pub fn window_expr_common_partition_keys(window_exprs: &[Expr]) -> Result<&[Expr
 
 /// Returns a validated `DataType` for the specified precision and
 /// scale
-pub fn make_decimal_type(
-    precision: Option<u64>,
-    scale: Option<u64>,
-) -> Result<DataType> {
+pub fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> Result<DataType> {
     // postgres like behavior
     let (precision, scale) = match (precision, scale) {
         (Some(p), Some(s)) => (p as u8, s as i8),


### PR DESCRIPTION
This patch fixes the field name of `CAST` expressions in LogicalPlan schemas.