### PR TITLE
Trino_date: human_readable_seconds()

### DIFF
--- a/extension/functions/src/presto.rs
+++ b/extension/functions/src/presto.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 use std::sync::Arc;
 
 use arrow::{
@@ -125,7 +124,6 @@ impl ScalarFunctionDef for HumanReadableSecondsFunction {
     }
 }
 
-
 #[derive(Debug)]
 pub struct CurrentTimeFunction;
 
@@ -157,7 +155,10 @@ pub struct FunctionPackage;
 
 impl ScalarFunctionPackage for FunctionPackage {
     fn functions(&self) -> Vec<Box<dyn ScalarFunctionDef>> {
-        vec![Box::new(HumanReadableSecondsFunction), Box::new(CurrentTimeFunction)]
+        vec![
+            Box::new(HumanReadableSecondsFunction),
+            Box::new(CurrentTimeFunction),
+        ]
     }
 }
 
@@ -189,9 +190,10 @@ mod test {
             "human_readable_seconds(56363463)",
             "93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds"
         );
-         Ok(())
+        Ok(())
     }
 
+    #[tokio::test]
     async fn test_current_time() -> Result<()> {
         let current = Local::now();
         let formatted = current.format("%H:%M:%S").to_string();

--- a/extension/functions/src/presto.rs
+++ b/extension/functions/src/presto.rs
@@ -17,8 +17,6 @@
 
 use arrow::{array::*, datatypes::DataType};
 use datafusion::error::Result;
-
-use datafusion_common::DataFusionError;
 use datafusion_expr::{
     ReturnTypeFunction, ScalarFunctionDef, ScalarFunctionPackage, Signature, Volatility,
 };
@@ -51,7 +49,7 @@ impl ScalarFunctionDef for HumanReadableSecondsFunction {
         let array = input_array
             .into_iter()
             .map(|sec| {
-                let seconds = sec.map(|value| value / 1_000_000_000.0).unwrap();
+                let seconds = sec.map(|value| value).unwrap();
                 let weeks = (seconds / 604800.0) as i64;
                 let days = ((seconds % 604800.0) / 86400.0) as i64;
                 let hours = ((seconds % 86400.0) / 3600.0) as i64;
@@ -61,30 +59,58 @@ impl ScalarFunctionDef for HumanReadableSecondsFunction {
                 let mut formatted = String::new();
 
                 if weeks > 0 {
-                    formatted +=
-                        &format!("{} week{}, ", weeks, if weeks > 1 { "s" } else { "" });
+                    formatted += &format!(
+                        "{} week{}{}",
+                        weeks,
+                        if weeks > 1 { "s" } else { "" },
+                        if days + hours + minutes + seconds_remainder > 0 {
+                            ", "
+                        } else {
+                            ""
+                        }
+                    ); //for splitting ,
                 }
                 if days > 0 {
-                    formatted +=
-                        &format!("{} day{}, ", days, if days > 1 { "s" } else { "" });
+                    formatted += &format!(
+                        "{} day{}{}",
+                        days,
+                        if days > 1 { "s" } else { "" },
+                        if hours + minutes + seconds_remainder > 0 {
+                            ", "
+                        } else {
+                            ""
+                        }
+                    ); //for splitting ,
                 }
                 if hours > 0 {
-                    formatted +=
-                        &format!("{} hour{}, ", hours, if hours > 1 { "s" } else { "" });
+                    formatted += &format!(
+                        "{} hour{}{}",
+                        hours,
+                        if hours > 1 { "s" } else { "" },
+                        if minutes + seconds_remainder > 0 {
+                            ", "
+                        } else {
+                            ""
+                        }
+                    ); //for splitting ,
                 }
                 if minutes > 0 {
                     formatted += &format!(
-                        "{} minute{}, ",
+                        "{} minute{}{}",
                         minutes,
-                        if minutes > 1 { "s" } else { "" }
+                        if minutes > 1 { "s" } else { "" },
+                        if seconds_remainder > 0 { ", " } else { "" }
                     );
                 }
                 if seconds_remainder > 0 {
                     formatted += &format!(
-                        "{} second{}, ",
+                        "{} second{}",
                         seconds_remainder,
                         if seconds_remainder > 1 { "s" } else { "" }
                     );
+                }
+                if weeks + days + hours + minutes + seconds_remainder == 0 {
+                    formatted = "0 second".to_string();
                 }
                 Some(formatted)
             })
@@ -115,12 +141,15 @@ mod test {
 
     #[tokio::test]
     async fn test_human_readable_seconds() -> Result<()> {
-        //test_expression!("human_readable_seconds(1.0)", "0 week, 0 day, 0 hour, 0 minute, 0 second");
         test_expression!("human_readable_seconds(604800.0)", "1 week");
         test_expression!("human_readable_seconds(86400.0)", "1 day");
         test_expression!("human_readable_seconds(3600.0)", "1 hour");
         test_expression!("human_readable_seconds(60.0)", "1 minute");
         test_expression!("human_readable_seconds(1.0)", "1 second");
+        test_expression!("human_readable_seconds(0.0)", "0 second");
+        test_expression!("human_readable_seconds(96)", "1 minute, 36 seconds");
+        test_expression!("human_readable_seconds(3762)", "1 hour, 2 minutes, 42 seconds");
+        test_expression!("human_readable_seconds(56363463)", "93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds");
         Ok(())
     }
 }

--- a/extension/functions/src/presto.rs
+++ b/extension/functions/src/presto.rs
@@ -14,3 +14,113 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+use arrow::{array::*, datatypes::DataType};
+use datafusion::error::Result;
+
+use datafusion_common::DataFusionError;
+use datafusion_expr::{
+    ReturnTypeFunction, ScalarFunctionDef, ScalarFunctionPackage, Signature, Volatility,
+};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct HumanReadableSecondsFunction;
+
+impl ScalarFunctionDef for HumanReadableSecondsFunction {
+    fn name(&self) -> &str {
+        "human_readable_seconds"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::exact(vec![DataType::Float64], Volatility::Immutable)
+    }
+
+    fn return_type(&self) -> ReturnTypeFunction {
+        let return_type = Arc::new(DataType::Utf8);
+        Arc::new(move |_| Ok(return_type.clone()))
+    }
+
+    fn execute(&self, args: &[ArrayRef]) -> Result<ArrayRef> {
+        assert_eq!(args.len(), 1);
+        let input_array = args[0]
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("cast to Float64Array failed");
+
+        let array = input_array
+            .into_iter()
+            .map(|sec| {
+                let seconds = sec.map(|value| value / 1_000_000_000.0).unwrap();
+                let weeks = (seconds / 604800.0) as i64;
+                let days = ((seconds % 604800.0) / 86400.0) as i64;
+                let hours = ((seconds % 86400.0) / 3600.0) as i64;
+                let minutes = ((seconds % 3600.0) / 60.0) as i64;
+                let seconds_remainder = (seconds % 60.0) as i64;
+
+                let mut formatted = String::new();
+
+                if weeks > 0 {
+                    formatted +=
+                        &format!("{} week{}, ", weeks, if weeks > 1 { "s" } else { "" });
+                }
+                if days > 0 {
+                    formatted +=
+                        &format!("{} day{}, ", days, if days > 1 { "s" } else { "" });
+                }
+                if hours > 0 {
+                    formatted +=
+                        &format!("{} hour{}, ", hours, if hours > 1 { "s" } else { "" });
+                }
+                if minutes > 0 {
+                    formatted += &format!(
+                        "{} minute{}, ",
+                        minutes,
+                        if minutes > 1 { "s" } else { "" }
+                    );
+                }
+                if seconds_remainder > 0 {
+                    formatted += &format!(
+                        "{} second{}, ",
+                        seconds_remainder,
+                        if seconds_remainder > 1 { "s" } else { "" }
+                    );
+                }
+                Some(formatted)
+            })
+            .collect::<StringArray>();
+
+        Ok(Arc::new(array) as ArrayRef)
+    }
+}
+
+// Function package declaration
+pub struct FunctionPackage;
+
+impl ScalarFunctionPackage for FunctionPackage {
+    fn functions(&self) -> Vec<Box<dyn ScalarFunctionDef>> {
+        vec![Box::new(HumanReadableSecondsFunction)]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use datafusion::error::Result;
+    use datafusion::prelude::SessionContext;
+    use tokio;
+
+    use crate::utils::{execute, test_expression};
+
+    use super::FunctionPackage;
+
+    #[tokio::test]
+    async fn test_human_readable_seconds() -> Result<()> {
+        //test_expression!("human_readable_seconds(1.0)", "0 week, 0 day, 0 hour, 0 minute, 0 second");
+        test_expression!("human_readable_seconds(604800.0)", "1 week");
+        test_expression!("human_readable_seconds(86400.0)", "1 day");
+        test_expression!("human_readable_seconds(3600.0)", "1 hour");
+        test_expression!("human_readable_seconds(60.0)", "1 minute");
+        test_expression!("human_readable_seconds(1.0)", "1 second");
+        Ok(())
+    }
+}

--- a/extension/functions/src/presto.rs
+++ b/extension/functions/src/presto.rs
@@ -148,8 +148,14 @@ mod test {
         test_expression!("human_readable_seconds(1.0)", "1 second");
         test_expression!("human_readable_seconds(0.0)", "0 second");
         test_expression!("human_readable_seconds(96)", "1 minute, 36 seconds");
-        test_expression!("human_readable_seconds(3762)", "1 hour, 2 minutes, 42 seconds");
-        test_expression!("human_readable_seconds(56363463)", "93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds");
+        test_expression!(
+            "human_readable_seconds(3762)",
+            "1 hour, 2 minutes, 42 seconds"
+        );
+        test_expression!(
+            "human_readable_seconds(56363463)",
+            "93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
human_readable_seconds for trino impl

## refer:
human_readable_seconds(double) → varchar[#](https://trino.io/docs/current/functions/datetime.html#human_readable_seconds)

```
Formats the double value of seconds into a human readable string containing weeks, days, hours, minutes, and seconds:

SELECT human_readable_seconds(96);
-- 1 minute, 36 seconds

SELECT human_readable_seconds(3762);
-- 1 hour, 2 minutes, 42 seconds

SELECT human_readable_seconds(56363463);
-- 93 weeks, 1 day, 8 hours, 31 minutes, 3 seconds
```