### PR TITLE
`from_unixtime` and `from_unixtime_nanos`

### DIFF
--- a/extension/functions/src/presto.rs
+++ b/extension/functions/src/presto.rs
@@ -481,7 +481,13 @@ impl ScalarFunctionDef for FromUnixtimeFunction {
     }
 
     fn signature(&self) -> Signature {
-        Signature::exact(vec![DataType::Int64], Volatility::Immutable)
+        Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Int64]),
+                //TypeSignature::Exact(vec![DataType::Int64, DataType::Utf8]),
+            ],
+            Volatility::Immutable,
+        )
     }
 
     fn return_type(&self) -> ReturnTypeFunction {


### PR DESCRIPTION
`from_unixtime` and `from_unixtime_nanos` WITHOUT timezone support.

`from_unixtime` needs more impl for timezone support.

-------
from_unixtime(unixtime) → timestamp(3) with time zone[#](https://trino.io/docs/current/functions/datetime.html#from_unixtime)
Returns the UNIX timestamp unixtime as a timestamp with time zone. unixtime is the number of seconds since 1970-01-01 00:00:00 UTC.

from_unixtime(unixtime, zone) → timestamp(3) with time zone
Returns the UNIX timestamp unixtime as a timestamp with time zone using zone for the time zone. unixtime is the number of seconds since 1970-01-01 00:00:00 UTC.

from_unixtime(unixtime, hours, minutes) → timestamp(3) with time zone
Returns the UNIX timestamp unixtime as a timestamp with time zone using hours and minutes for the time zone offset. unixtime is the number of seconds since 1970-01-01 00:00:00 in double data type.

from_unixtime_nanos(unixtime) → timestamp(9) with time zone[#](https://trino.io/docs/current/functions/datetime.html#from_unixtime_nanos)
Returns the UNIX timestamp unixtime as a timestamp with time zone. unixtime is the number of nanoseconds since 1970-01-01 00:00:00.000000000 UTC: