### PR TITLE
Trino date: day_of_week & day_of_year

### DIFF
--- a/extension/functions/src/presto.rs
+++ b/extension/functions/src/presto.rs
@@ -819,7 +819,8 @@ impl ScalarFunctionDef for DayOfYearFunction {
                                     timestamp / 1_000_000_000,
                                     (timestamp % 1_000_000_000) as u32,
                                 );
-                                datetime.map(|dt| dt.ordinal() as i64).unwrap_or(0) // day of the year
+                                datetime.map(|dt| dt.ordinal() as i64).unwrap_or(0)
+                                // day of the year
                             })
                             .unwrap_or(0)
                     })
@@ -834,8 +835,6 @@ impl ScalarFunctionDef for DayOfYearFunction {
         Ok(result?)
     }
 }
-
-// Rest of your implementation...
 // Function package declaration
 pub struct FunctionPackage;
 


### PR DESCRIPTION
day_of_week & day_of_year
```

day_of_week(x) → bigint[#](https://trino.io/docs/current/functions/datetime.html#day_of_week)
Returns the ISO day of the week from x. The value ranges from 1 (Monday) to 7 (Sunday).

day_of_year(x) → bigint[#](https://trino.io/docs/current/functions/datetime.html#day_of_year)
Returns the day of the year from x. The value ranges from 1 to 366.
```