### PR TITLE
Revert "Merge pull request #67 from sdf-labs/vlad/get_field-return_type"

### DIFF
--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -56,27 +56,8 @@ impl ScalarUDFImpl for GetFieldFunc {
         &self.signature
     }
 
-    fn return_type(&self, args: &[DataType]) -> Result<DataType> {
-        if let DataType::Map(entries, _) = &args[0] {
-            if let DataType::Struct(fields) = entries.data_type() {
-                let value_dt = fields
-                    .iter()
-                    .find_map(|field| {
-                        if field.name() == "values" {
-                            Some(field.data_type())
-                        } else {
-                            None
-                        }
-                    })
-                    .expect("map type without value is not supported");
-                return Ok(value_dt.clone());
-            }
-            return exec_err!("Malformed DataType::Map -- does not wrap over a DataType::Struct, got {}", &args[0]);
-        }
-        todo!(
-            "get_field function is not implemented for this type: {}",
-            &args[0]
-        );
+    fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+        todo!()
     }
 
     fn return_type_from_exprs(


### PR DESCRIPTION
This reverts commit e97786ad3533416e528013ac14ed47529995297d, reversing changes made to f1d5e7cae9a53324f584c9fb49357a440af736b7.

The implementation of return_type() in get_field UDF is no longer needed, since we'll be switching in SDF to calling return_type_from_exprs() instead.

