### PR TITLE
Enable symbolic evaluation for filter, joins, unions and in-list filter expressions

### DIFF
--- a/datafusion-examples/examples/custom_datasource.rs
+++ b/datafusion-examples/examples/custom_datasource.rs
@@ -84,7 +84,6 @@ async fn search_accounts(
         let record_batch = result.first().unwrap();
 
         assert_eq!(expected_result_length, record_batch.column(1).len());
-        dbg!(record_batch.columns());
     })
     .await
     .unwrap();

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -721,43 +721,43 @@ impl DefaultPhysicalPlanner {
                 let (aggregates, filters, _order_bys): (Vec<_>, Vec<_>, Vec<_>) =
                     multiunzip(agg_filter);
 
-                let initial_aggr = Arc::new(AggregateExec::try_new(
-                    AggregateMode::Partial,
-                    groups.clone(),
-                    aggregates,
-                    filters.clone(),
-                    input_exec,
-                    Arc::clone(&physical_input_schema),
-                )?);
+                // let initial_aggr = Arc::new(AggregateExec::try_new(
+                //     AggregateMode::Single,
+                //     groups.clone(),
+                //     aggregates,
+                //     filters.clone(),
+                //     input_exec,
+                //     Arc::clone(&physical_input_schema),
+                // )?);
 
-                let can_repartition = !groups.is_empty()
-                    && session_state.config().target_partitions() > 1
-                    && session_state.config().repartition_aggregations();
+                // let can_repartition = !groups.is_empty()
+                //     && session_state.config().target_partitions() > 1
+                //     && session_state.config().repartition_aggregations();
 
-                // Some aggregators may be modified during initialization for
-                // optimization purposes. For example, a FIRST_VALUE may turn
-                // into a LAST_VALUE with the reverse ordering requirement.
-                // To reflect such changes to subsequent stages, use the updated
-                // `AggregateFunctionExpr`/`PhysicalSortExpr` objects.
-                let updated_aggregates = initial_aggr.aggr_expr().to_vec();
+                // // Some aggregators may be modified during initialization for
+                // // optimization purposes. For example, a FIRST_VALUE may turn
+                // // into a LAST_VALUE with the reverse ordering requirement.
+                // // To reflect such changes to subsequent stages, use the updated
+                // // `AggregateFunctionExpr`/`PhysicalSortExpr` objects.
+                // let updated_aggregates = initial_aggr.aggr_expr().to_vec();
 
-                let next_partition_mode = if can_repartition {
-                    // construct a second aggregation with 'AggregateMode::FinalPartitioned'
-                    AggregateMode::FinalPartitioned
-                } else {
-                    // construct a second aggregation, keeping the final column name equal to the
-                    // first aggregation and the expressions corresponding to the respective aggregate
-                    AggregateMode::Final
-                };
+                // let next_partition_mode = if can_repartition {
+                //     // construct a second aggregation with 'AggregateMode::FinalPartitioned'
+                //     AggregateMode::FinalPartitioned
+                // } else {
+                //     // construct a second aggregation, keeping the final column name equal to the
+                //     // first aggregation and the expressions corresponding to the respective aggregate
+                //     AggregateMode::Final
+                // };
 
-                let final_grouping_set = initial_aggr.group_expr().as_final();
+                // let final_grouping_set = initial_aggr.group_expr().as_final();
 
                 Arc::new(AggregateExec::try_new(
-                    next_partition_mode,
-                    final_grouping_set,
-                    updated_aggregates,
+                    AggregateMode::Single,
+                    groups.clone(),
+                    aggregates,
                     filters,
-                    initial_aggr,
+                    input_exec,
                     Arc::clone(&physical_input_schema),
                 )?)
             }

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -160,8 +160,6 @@ impl ColumnarValue {
                         let symbolic_data = make_colref_symbolic_expr_array(
                             tbl,
                             column_position,
-                            num_rows,
-                            row_offset,
                             arrow_type_to_var_type(data_type),
                         );
                         array_clone.with_symbolic_data(&symbolic_data)
@@ -177,8 +175,6 @@ impl ColumnarValue {
                         let symbolic_data = make_colref_symbolic_expr_array(
                             tbl,
                             column_position,
-                            num_rows,
-                            row_offset,
                             arrow_type_to_var_type(data_type),
                         );
                         arr_clone.with_symbolic_data(&symbolic_data)

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -17,7 +17,9 @@
 
 //! [`ColumnarValue`] represents the result of evaluating an expression.
 
-use arrow::array::{make_colref_symbolic_expr_array, Array, ArrayRef, NullArray};
+use arrow::array::{
+    arrow_type_to_var_type, make_colref_symbolic_expr_array, Array, ArrayRef, NullArray,
+};
 use arrow::compute::{kernels, CastOptions};
 use arrow::datatypes::DataType;
 use arrow::util::pretty::pretty_format_columns;
@@ -145,27 +147,41 @@ impl ColumnarValue {
     pub fn into_maybe_symbolic_array(
         self,
         num_rows: usize,
+        row_offset: usize,
         table_name: Option<String>,
         column_position: usize,
     ) -> Result<ArrayRef> {
         Ok(match self {
-            ColumnarValue::Array(array) => table_name
-                .map(|tbl| {
-                    let symbolic_data =
-                        make_colref_symbolic_expr_array(tbl, column_position, num_rows);
-                    array.with_symbolic_data(&symbolic_data)
-                })
-                .unwrap_or(array),
-            ColumnarValue::Scalar(scalar) => {
-                let arr = scalar.to_array_of_size(num_rows)?;
+            ColumnarValue::Array(array) => {
+                let array_clone = Arc::clone(&array);
+                let data_type = array.data_type().clone();
                 table_name
                     .map(|tbl| {
                         let symbolic_data = make_colref_symbolic_expr_array(
                             tbl,
                             column_position,
                             num_rows,
+                            row_offset,
+                            arrow_type_to_var_type(data_type),
                         );
-                        arr.with_symbolic_data(&symbolic_data)
+                        array_clone.with_symbolic_data(&symbolic_data)
+                    })
+                    .unwrap_or(array)
+            }
+            ColumnarValue::Scalar(scalar) => {
+                let arr = scalar.to_array_of_size(num_rows)?;
+                let arr_clone = Arc::clone(&arr);
+                let data_type = arr.data_type().clone();
+                table_name
+                    .map(|tbl| {
+                        let symbolic_data = make_colref_symbolic_expr_array(
+                            tbl,
+                            column_position,
+                            num_rows,
+                            row_offset,
+                            arrow_type_to_var_type(data_type),
+                        );
+                        arr_clone.with_symbolic_data(&symbolic_data)
                     })
                     .unwrap_or(arr)
             }

--- a/datafusion/functions-aggregate-common/src/aggregate/count_distinct/native.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/count_distinct/native.rs
@@ -30,6 +30,7 @@ use ahash::RandomState;
 use arrow::array::types::ArrowPrimitiveType;
 use arrow::array::ArrayRef;
 use arrow::array::PrimitiveArray;
+use arrow::array::SymbolicExpr;
 use arrow::datatypes::DataType;
 
 use datafusion_common::cast::{as_list_array, as_primitive_array};

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -120,13 +120,11 @@ where
 
         let lhs = v.to_symbolic_data();
         let rhs = self.array.to_symbolic_data();
-        let symbolic_data = lhs.iter().map(|(lhs)| {
-            SymbolicExpr::BinaryExpr {
-                left: Box::new(lhs.clone()),
-                op: SymbolicOperator::In,
-                right: Box::new(SymbolicExpr::List(rhs.clone())),
-            }
-        }).collect::<Vec<_>>();
+        let symbolic_data = SymbolicExpr::BinaryExpr {
+            left: Box::new(lhs.clone()),
+            op: SymbolicOperator::In,
+            right: Box::new(SymbolicExpr::List(vec![rhs.clone()])),
+        };
 
         let _res: BooleanArray = ArrayIter::new(v)
             .map(|v| {
@@ -148,7 +146,7 @@ where
             })
             .collect();
 
-        Ok(_res.with_symbolic_data(symbolic_data.as_slice()))
+        Ok(_res.with_symbolic_data(&symbolic_data))
     }
 
     fn has_nulls(&self) -> bool {

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -118,13 +118,15 @@ where
         let in_array = &self.array;
         let has_nulls = in_array.null_count() != 0;
 
-        let lhs = v.to_symbolic_data().get(0).unwrap().clone();
+        let lhs = v.to_symbolic_data();
         let rhs = self.array.to_symbolic_data();
-        let symbolic_data = SymbolicExpr::BinaryExpr {
-            left: Box::new(lhs),
-            op: SymbolicOperator::In,
-            right: Box::new(SymbolicExpr::List(rhs)),
-        };
+        let symbolic_data = lhs.iter().map(|(lhs)| {
+            SymbolicExpr::BinaryExpr {
+                left: Box::new(lhs.clone()),
+                op: SymbolicOperator::In,
+                right: Box::new(SymbolicExpr::List(rhs.clone())),
+            }
+        }).collect::<Vec<_>>();
 
         let _res: BooleanArray = ArrayIter::new(v)
             .map(|v| {
@@ -146,7 +148,7 @@ where
             })
             .collect();
 
-        Ok(_res.with_symbolic_data(&[symbolic_data]))
+        Ok(_res.with_symbolic_data(symbolic_data.as_slice()))
     }
 
     fn has_nulls(&self) -> bool {

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use crate::physical_expr::physical_exprs_bag_equal;
 use crate::PhysicalExpr;
 
+use arrow::array::BooleanArray;
 use arrow::array::*;
 use arrow::buffer::BooleanBuffer;
 use arrow::compute::kernels::boolean::{not, or_kleene};
@@ -117,7 +118,15 @@ where
         let in_array = &self.array;
         let has_nulls = in_array.null_count() != 0;
 
-        Ok(ArrayIter::new(v)
+        let lhs = v.to_symbolic_data().get(0).unwrap().clone();
+        let rhs = self.array.to_symbolic_data();
+        let symbolic_data = SymbolicExpr::BinaryExpr {
+            left: Box::new(lhs),
+            op: SymbolicOperator::In,
+            right: Box::new(SymbolicExpr::List(rhs)),
+        };
+
+        let _res: BooleanArray = ArrayIter::new(v)
             .map(|v| {
                 v.and_then(|v| {
                     let hash = v.hash_one(&self.hash_set.state);
@@ -135,7 +144,9 @@ where
                     }
                 })
             })
-            .collect())
+            .collect();
+
+        Ok(_res.with_symbolic_data(&[symbolic_data]))
     }
 
     fn has_nulls(&self) -> bool {
@@ -377,8 +388,7 @@ impl PhysicalExpr for InListExpr {
             }
         };
         let _res = ColumnarValue::Array(Arc::new(r));
-        unimplemented!()
-        // Ok(_res)
+        Ok(_res)
     }
 
     fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -35,6 +35,7 @@ use crate::{
 };
 
 use arrow::array::ArrayRef;
+use arrow::array::SymbolicExpr;
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use arrow_array::{UInt16Array, UInt32Array, UInt64Array, UInt8Array};
@@ -1198,6 +1199,7 @@ pub fn create_accumulators(
 pub fn finalize_aggregation(
     accumulators: &mut [AccumulatorItem],
     mode: &AggregateMode,
+    batch_constraints: &Option<SymbolicExpr>,
 ) -> Result<Vec<ArrayRef>> {
     match mode {
         AggregateMode::Partial => {
@@ -1222,6 +1224,15 @@ pub fn finalize_aggregation(
             accumulators
                 .iter_mut()
                 .map(|accumulator| accumulator.evaluate().and_then(|v| v.to_array()))
+                .map(|v| {
+                    v.and_then(|array| {
+                        if let Some(batch_constraints) = batch_constraints {
+                            Ok(array.with_symbolic_data(&batch_constraints))
+                        } else {
+                            Ok(array)
+                        }
+                    })
+                })
                 .collect()
         }
     }

--- a/datafusion/physical-plan/src/aggregates/no_grouping.rs
+++ b/datafusion/physical-plan/src/aggregates/no_grouping.rs
@@ -24,7 +24,7 @@ use crate::aggregates::{
 use crate::metrics::{BaselineMetrics, RecordOutput};
 use crate::{RecordBatchStream, SendableRecordBatchStream};
 use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::Result;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::PhysicalExpr;
@@ -108,10 +108,19 @@ impl AggregateStream {
             }
 
             let elapsed_compute = this.baseline_metrics.elapsed_compute();
+            let mut constraints = vec![];
+            let mut row_symbolic_data = vec![];
 
             loop {
                 let result = match this.input.next().await {
                     Some(Ok(batch)) => {
+                        dbg!(&batch); 
+                        if let Some(batch_constraints) = batch.constraints() {
+                            constraints.extend(batch_constraints.to_vec());
+                        }
+                        if let Some(batch_row_symbolic_data) = batch.row_symbolic_data() {
+                            row_symbolic_data.extend(batch_row_symbolic_data.to_vec());
+                        }
                         let timer = elapsed_compute.timer();
                         let result = aggregate_batch(
                             &this.mode,
@@ -137,17 +146,25 @@ impl AggregateStream {
                     None => {
                         this.finished = true;
                         let timer = this.baseline_metrics.elapsed_compute().timer();
-                        let result =
-                            finalize_aggregation(&mut this.accumulators, &this.mode)
-                                .and_then(|columns| {
-                                    RecordBatch::try_new(
-                                        Arc::clone(&this.schema),
-                                        columns,
-                                    )
-                                    .map_err(Into::into)
-                                })
-                                .record_output(&this.baseline_metrics);
+                        let result = finalize_aggregation(
+                            &mut this.accumulators,
+                            &this.mode,
+                        )
+                        .and_then(|columns| {
+                            RecordBatch::try_new_with_options_and_constraints_and_symbolic_data(
+                                Arc::clone(&this.schema),
+                                columns,
+                                &RecordBatchOptions::new(),
+                                Some(row_symbolic_data),
+                                Some(constraints),
+                            )
+                            .map_err(Into::into)
+                        })
+                        .record_output(&this.baseline_metrics);
 
+                        match agg.aggr_expr
+
+                        dbg!(&result.as_ref().ok());
                         timer.done();
 
                         result

--- a/datafusion/physical-plan/src/aggregates/no_grouping.rs
+++ b/datafusion/physical-plan/src/aggregates/no_grouping.rs
@@ -23,11 +23,13 @@ use crate::aggregates::{
 };
 use crate::metrics::{BaselineMetrics, RecordOutput};
 use crate::{RecordBatchStream, SendableRecordBatchStream};
+use arrow::array::{ArrayRef, SymbolicExpr, SymbolicFunctions};
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::Result;
 use datafusion_execution::TaskContext;
-use datafusion_physical_expr::PhysicalExpr;
+use datafusion_expr::Expr;
+use datafusion_physical_expr::{expressions::Column, PhysicalExpr};
 use futures::stream::BoxStream;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -38,6 +40,7 @@ use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use futures::stream::{Stream, StreamExt};
 
 use super::AggregateExec;
+use arrow::array::ListArray;
 
 /// stream struct for aggregation without grouping columns
 pub(crate) struct AggregateStream {
@@ -61,6 +64,7 @@ struct AggregateStreamInner {
     filter_expressions: Vec<Option<Arc<dyn PhysicalExpr>>>,
     accumulators: Vec<AccumulatorItem>,
     reservation: MemoryReservation,
+    batch_constraints: Option<SymbolicExpr>,
     finished: bool,
 }
 
@@ -100,6 +104,7 @@ impl AggregateStream {
             filter_expressions,
             accumulators,
             reservation,
+            batch_constraints: None,
             finished: false,
         };
         let stream = futures::stream::unfold(inner, |mut this| async move {
@@ -108,20 +113,36 @@ impl AggregateStream {
             }
 
             let elapsed_compute = this.baseline_metrics.elapsed_compute();
-            let mut constraints = vec![];
-            let mut row_symbolic_data = vec![];
 
             loop {
                 let result = match this.input.next().await {
                     Some(Ok(batch)) => {
-                        dbg!(&batch); 
-                        if let Some(batch_constraints) = batch.constraints() {
-                            constraints.extend(batch_constraints.to_vec());
-                        }
-                        if let Some(batch_row_symbolic_data) = batch.row_symbolic_data() {
-                            row_symbolic_data.extend(batch_row_symbolic_data.to_vec());
-                        }
                         let timer = elapsed_compute.timer();
+
+                        if this.batch_constraints.is_none() {
+                            if let Some(c) = batch.constraints() {
+                                let agg_column_index = if let Some(col) = this
+                                    .aggregate_expressions[0][0]
+                                    .as_any()
+                                    .downcast_ref::<Column>()
+                                {
+                                    col.index()
+                                } else {
+                                    panic!("Expected column expression")
+                                };
+                                let agg_column = batch.column(agg_column_index);
+                                let column_expr =
+                                    batch.column(agg_column_index).to_symbolic_data();
+                                let batch_constraints = SymbolicExpr::function(
+                                    SymbolicFunctions::Count,
+                                    column_expr,
+                                    true,
+                                    batch.constraints().unwrap(),
+                                );
+                                this.batch_constraints = Some(batch_constraints);
+                            }
+                        }
+
                         let result = aggregate_batch(
                             &this.mode,
                             batch,
@@ -149,24 +170,44 @@ impl AggregateStream {
                         let result = finalize_aggregation(
                             &mut this.accumulators,
                             &this.mode,
+                            &this.batch_constraints,
                         )
                         .and_then(|columns| {
-                            RecordBatch::try_new_with_options_and_constraints_and_symbolic_data(
-                                Arc::clone(&this.schema),
-                                columns,
-                                &RecordBatchOptions::new(),
-                                Some(row_symbolic_data),
-                                Some(constraints),
-                            )
-                            .map_err(Into::into)
+                            // let mut new_columns = vec![];
+                            // for col in &columns {
+                            //     new_columns.push(col.with_symbolic_data(
+                            //         &batch_constraints.clone().unwrap(),
+                            //     ));
+                            // }
+                            let mut contains_list_array = false;
+                            for col in &columns {
+                                if col.as_any().downcast_ref::<ListArray>().is_some() {
+                                    contains_list_array = true;
+                                    break;
+                                }
+                            }
+                            let batch = if contains_list_array {
+                                RecordBatch::try_new_with_options_and_constraints(
+                                    Arc::clone(&this.schema),
+                                    columns,
+                                    &RecordBatchOptions::new(),
+                                    this.batch_constraints.clone(),
+                                )?
+                            } else {
+                                RecordBatch::try_new_with_constraints(
+                                    Arc::clone(&this.schema),
+                                    columns,
+                                    Some(SymbolicExpr::generic_row(
+                                        "_".to_string(),
+                                        None,
+                                    )),
+                                )?
+                            };
+                            Ok(batch)
                         })
                         .record_output(&this.baseline_metrics);
 
-                        match agg.aggr_expr
-
-                        dbg!(&result.as_ref().ok());
                         timer.done();
-
                         result
                     }
                 };

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -271,12 +271,11 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
         .collect();
     let mut options = RecordBatchOptions::new();
     options = options.with_row_count(Some(batch.num_rows()));
-    RecordBatch::try_new_with_options_and_constraints_and_symbolic_data(
+    RecordBatch::try_new_with_options_and_constraints(
         batch.schema(),
         new_columns,
         &options,
-        batch.row_symbolic_data().map(|c| c.to_vec()),
-        batch.constraints().map(|c| c.to_vec()),
+        batch.constraints(),
     )
     .expect("Failed to re-create the gc'ed record batch")
 }

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -177,7 +177,6 @@ impl BatchCoalescer {
         let batch = concat_batches(&self.schema, &self.buffer)?;
         self.buffer.clear();
         self.buffered_rows = 0;
-        dbg!(&batch);
         Ok(batch)
     }
 }
@@ -272,7 +271,6 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
         .collect();
     let mut options = RecordBatchOptions::new();
     options = options.with_row_count(Some(batch.num_rows()));
-    dbg!(&batch.constraints());
     RecordBatch::try_new_with_options_and_constraints(
         batch.schema(),
         new_columns,

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -271,10 +271,11 @@ fn gc_string_view_batch(batch: &RecordBatch) -> RecordBatch {
         .collect();
     let mut options = RecordBatchOptions::new();
     options = options.with_row_count(Some(batch.num_rows()));
-    RecordBatch::try_new_with_options_and_constraints(
+    RecordBatch::try_new_with_options_and_constraints_and_symbolic_data(
         batch.schema(),
         new_columns,
         &options,
+        batch.row_symbolic_data().map(|c| c.to_vec()),
         batch.constraints().map(|c| c.to_vec()),
     )
     .expect("Failed to re-create the gc'ed record batch")

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -228,7 +228,6 @@ impl Stream for CoalesceBatchesStream {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let poll = self.poll_next_inner(cx);
-        dbg!(&poll);
         self.baseline_metrics.record_poll(poll)
     }
 
@@ -293,7 +292,6 @@ impl CoalesceBatchesStream {
                 CoalesceBatchesStreamState::Pull => {
                     // Attempt to pull the next batch from the input stream.
                     let input_batch = ready!(self.input.poll_next_unpin(cx));
-                    dbg!(&self.input.schema(), &input_batch);
                     // Start timing the operation. The timer records time upon being dropped.
                     let _timer = cloned_time.timer();
 

--- a/datafusion/physical-plan/src/common.rs
+++ b/datafusion/physical-plan/src/common.rs
@@ -43,7 +43,6 @@ pub(crate) type SharedMemoryReservation = Arc<Mutex<MemoryReservation>>;
 /// Create a vector of record batches from a stream
 pub async fn collect(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatch>> {
     let res = stream.try_collect::<Vec<_>>().await;
-    dbg!(&res);
     res
 }
 

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -846,6 +846,7 @@ pub async fn collect(
     plan: Arc<dyn ExecutionPlan>,
     context: Arc<TaskContext>,
 ) -> Result<Vec<RecordBatch>> {
+    // dbg!(&plan);
     let stream = execute_stream(plan, context)?;
     crate::common::collect(stream).await
 }
@@ -862,6 +863,7 @@ pub fn execute_stream(
     plan: Arc<dyn ExecutionPlan>,
     context: Arc<TaskContext>,
 ) -> Result<SendableRecordBatchStream> {
+    dbg!(&plan);
     match plan.output_partitioning().partition_count() {
         0 => Ok(Box::pin(EmptyRecordBatchStream::new(plan.schema()))),
         1 => plan.execute(0, context),

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -559,7 +559,6 @@ impl Stream for FilterExecStream {
                         self.projection.as_ref(),
                         &self.schema,
                     )?;
-                    dbg!(&filtered_batch);
                     timer.done();
                     // Skip entirely filtered batches
                     // if filtered_batch.num_rows() == 0 {

--- a/datafusion/physical-plan/src/joins/hash_join.rs
+++ b/datafusion/physical-plan/src/joins/hash_join.rs
@@ -1480,7 +1480,7 @@ impl HashJoinStream {
         )?;
 
         // apply join filter if exists
-        let (left_indices, right_indices) = if let Some(filter) = &self.filter {
+        let (left_indices, right_indices, predicate) = if let Some(filter) = &self.filter {
             apply_join_filter_to_indices(
                 build_side.left_data.batch(),
                 &state.batch,
@@ -1490,7 +1490,7 @@ impl HashJoinStream {
                 JoinSide::Left,
             )?
         } else {
-            (left_indices, right_indices)
+            (left_indices, right_indices, BooleanArray::from(vec![false]))
         };
 
         // mark joined left-side indices as visited, if required by join type

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -48,12 +48,17 @@ use crate::{
     SendableRecordBatchStream,
 };
 
-use arrow::array::{BooleanBufferBuilder, UInt32Array, UInt64Array};
+use arrow::array::{
+    BooleanArray, BooleanBufferBuilder, SymbolicExpr, UInt32Array, UInt64Array,
+};
+
 use arrow::compute::concat_batches;
 use arrow::datatypes::{Schema, SchemaRef};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use arrow_array::Array;
 use datafusion_common::{
-    exec_datafusion_err, internal_err, project_schema, JoinSide, Result, Statistics,
+    arrow_err, exec_datafusion_err, internal_err, project_schema, DataFusionError,
+    JoinSide, Result, Statistics,
 };
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_execution::TaskContext;
@@ -738,7 +743,7 @@ fn build_join_indices(
     right_batch: &RecordBatch,
     filter: Option<&JoinFilter>,
     indices_cache: &mut (UInt64Array, UInt32Array),
-) -> Result<(UInt64Array, UInt32Array)> {
+) -> Result<(UInt64Array, UInt32Array, BooleanArray)> {
     let left_row_count = left_batch.num_rows();
     let right_row_count = right_batch.num_rows();
     let output_row_count = left_row_count * right_row_count;
@@ -781,16 +786,17 @@ fn build_join_indices(
         };
 
     if let Some(filter) = filter {
-        apply_join_filter_to_indices(
+        let (left_indices, right_indices, predicate) = apply_join_filter_to_indices(
             left_batch,
             right_batch,
             left_indices,
             right_indices,
             filter,
             JoinSide::Left,
-        )
+        )?;
+        Ok((left_indices, right_indices, predicate))
     } else {
-        Ok((left_indices, right_indices))
+        todo!()
     }
 }
 
@@ -967,7 +973,7 @@ fn join_left_and_right_batch(
     indices_cache: &mut (UInt64Array, UInt32Array),
     right_side_ordered: bool,
 ) -> Result<RecordBatch> {
-    let (left_side, right_side) =
+    let (left_side, right_side, predicate) =
         build_join_indices(left_batch, right_batch, filter, indices_cache).map_err(
             |e| {
                 exec_datafusion_err!(
@@ -993,7 +999,7 @@ fn join_left_and_right_batch(
         right_side_ordered,
     )?;
 
-    build_batch_from_indices(
+    let joined_batch = build_batch_from_indices(
         schema,
         left_batch,
         right_batch,
@@ -1001,7 +1007,39 @@ fn join_left_and_right_batch(
         &right_side,
         column_indices,
         JoinSide::Left,
+    )?;
+
+    let mut all_constraints = vec![];
+    if let Some(left_constraints) = left_batch.constraints() {
+        all_constraints.extend(left_constraints.to_vec());
+    }
+    if let Some(right_constraints) = right_batch.constraints() {
+        all_constraints.extend(right_constraints.to_vec());
+    }
+    let constraints = predicate.to_maybe_symbolic_data().map(|exprs| {
+        exprs
+            .iter()
+            .enumerate()
+            .map(|(i, expr)| {
+                if predicate.is_null(i) || !predicate.value(i) {
+                    SymbolicExpr::not(expr.clone())
+                } else {
+                    expr.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+    });
+    all_constraints.extend(constraints.unwrap_or_default().to_vec());
+    let options =
+        RecordBatchOptions::default().with_row_count(Some(joined_batch.num_rows()));
+
+    RecordBatch::try_new_with_options_and_constraints(
+        joined_batch.schema(),
+        joined_batch.columns().to_vec(),
+        &options,
+        Some(all_constraints),
     )
+    .map_err(|e| DataFusionError::ArrowError(e, None))
 }
 
 impl<T: BatchTransformer + Unpin + Send> Stream for NestedLoopJoinStream<T> {

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -49,7 +49,8 @@ use crate::{
 };
 
 use arrow::array::{
-    BooleanArray, BooleanBufferBuilder, SymbolicExpr, UInt32Array, UInt64Array,
+    BooleanArray, BooleanBufferBuilder, SymbolicExpr, SymbolicOperator, UInt32Array,
+    UInt64Array,
 };
 
 use arrow::compute::concat_batches;
@@ -1009,27 +1010,26 @@ fn join_left_and_right_batch(
         JoinSide::Left,
     )?;
 
-    let mut all_constraints = vec![];
-    if let Some(left_constraints) = left_batch.constraints() {
-        all_constraints.extend(left_constraints.to_vec());
+    let join_predicate = predicate.to_maybe_symbolic_data();
+    let left_constraints = match left_batch.constraints().unwrap() {
+        SymbolicExpr::GenericRow { constraints, .. } => constraints,
+        _ => panic!("Expected left_batch to have constraints"),
+    };
+    let right_constraints = match right_batch.constraints().unwrap() {
+        SymbolicExpr::GenericRow { constraints, .. } => constraints,
+        _ => panic!("Expected right_batch to have constraints"),
+    };
+    let mut joined_constraints = vec![];
+    joined_constraints.extend(left_constraints.unwrap());
+    joined_constraints.extend(right_constraints.unwrap());
+    if let Some(join_predicate) = join_predicate {
+        joined_constraints.push(join_predicate);
     }
-    if let Some(right_constraints) = right_batch.constraints() {
-        all_constraints.extend(right_constraints.to_vec());
-    }
-    let constraints = predicate.to_maybe_symbolic_data().map(|exprs| {
-        exprs
-            .iter()
-            .enumerate()
-            .map(|(i, expr)| {
-                if predicate.is_null(i) || !predicate.value(i) {
-                    SymbolicExpr::not(expr.clone())
-                } else {
-                    expr.clone()
-                }
-            })
-            .collect::<Vec<_>>()
-    });
-    all_constraints.extend(constraints.unwrap_or_default().to_vec());
+
+    let joined_constraints = SymbolicExpr::GenericRow {
+        table: "_".to_string(),
+        constraints: Some(joined_constraints),
+    };
     let options =
         RecordBatchOptions::default().with_row_count(Some(joined_batch.num_rows()));
 
@@ -1037,7 +1037,7 @@ fn join_left_and_right_batch(
         joined_batch.schema(),
         joined_batch.columns().to_vec(),
         &options,
-        Some(all_constraints),
+        Some(joined_constraints),
     )
     .map_err(|e| DataFusionError::ArrowError(e, None))
 }

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -60,7 +60,7 @@ use crate::{
 
 use arrow::array::{
     ArrowPrimitiveType, NativeAdapter, PrimitiveArray, PrimitiveBuilder, UInt32Array,
-    UInt64Array,
+    UInt64Array, BooleanArray,
 };
 use arrow::compute::concat_batches;
 use arrow::datatypes::{Schema, SchemaRef};
@@ -940,7 +940,7 @@ pub(crate) fn join_with_probe_batch(
         Some(build_hash_joiner.deleted_offset),
     )?;
 
-    let (build_indices, probe_indices) = if let Some(filter) = filter {
+    let (build_indices, probe_indices, predicate) = if let Some(filter) = filter {
         apply_join_filter_to_indices(
             &build_hash_joiner.input_buffer,
             probe_batch,
@@ -950,7 +950,7 @@ pub(crate) fn join_with_probe_batch(
             build_hash_joiner.build_side,
         )?
     } else {
-        (build_indices, probe_indices)
+        (build_indices, probe_indices, BooleanArray::from(vec![false]))
     };
 
     if need_to_produce_result_in_final(build_hash_joiner.build_side, join_type) {

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -33,8 +33,8 @@ use crate::{
 pub use super::join_filter::JoinFilter;
 
 use arrow::array::{
-    downcast_array, new_null_array, Array, BooleanBufferBuilder, UInt32Array,
-    UInt32Builder, UInt64Array, BooleanArray,
+    downcast_array, new_null_array, Array, BooleanArray, BooleanBufferBuilder,
+    UInt32Array, UInt32Builder, UInt64Array,
 };
 use arrow::compute;
 use arrow::datatypes::{Field, Schema, SchemaBuilder, UInt32Type, UInt64Type};
@@ -1170,9 +1170,13 @@ pub(crate) fn apply_join_filter_to_indices(
     filter: &JoinFilter,
     build_side: JoinSide,
 ) -> Result<(UInt64Array, UInt32Array, BooleanArray)> {
-    if build_indices.is_empty() && probe_indices.is_empty() {
-        return Ok((build_indices, probe_indices, BooleanArray::from(vec![false])));
-    };
+    // if build_indices.is_empty() && probe_indices.is_empty() {
+    //     return Ok((
+    //         build_indices,
+    //         probe_indices,
+    //         BooleanArray::from(vec![false]),
+    //     ));
+    // };
     let intermediate_batch = build_batch_from_indices(
         filter.schema(),
         build_input_buffer,
@@ -1231,7 +1235,9 @@ pub(crate) fn build_batch_from_indices(
             Arc::new(compute::is_not_null(probe_indices)?)
         } else if column_index.side == build_side {
             let array = build_input_buffer.column(column_index.index);
-            if array.is_empty() || build_indices.null_count() == build_indices.len() {
+            let res = if array.is_empty()
+                || build_indices.null_count() == build_indices.len()
+            {
                 // Outer join would generate a null index when finding no match at our side.
                 // Therefore, it's possible we are empty but need to populate an n-length null array,
                 // where n is the length of the index array.
@@ -1239,15 +1245,19 @@ pub(crate) fn build_batch_from_indices(
                 new_null_array(array.data_type(), build_indices.len())
             } else {
                 compute::take(array.as_ref(), build_indices, None)?
-            }
+            };
+            res.with_symbolic_data(&array.to_symbolic_data())
         } else {
             let array = probe_batch.column(column_index.index);
-            if array.is_empty() || probe_indices.null_count() == probe_indices.len() {
+            let res = if array.is_empty()
+                || probe_indices.null_count() == probe_indices.len()
+            {
                 assert_eq!(probe_indices.null_count(), probe_indices.len());
                 new_null_array(array.data_type(), probe_indices.len())
             } else {
                 compute::take(array.as_ref(), probe_indices, None)?
-            }
+            };
+            res.with_symbolic_data(&array.to_symbolic_data())
         };
         columns.push(array);
     }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -34,7 +34,7 @@ pub use super::join_filter::JoinFilter;
 
 use arrow::array::{
     downcast_array, new_null_array, Array, BooleanBufferBuilder, UInt32Array,
-    UInt32Builder, UInt64Array,
+    UInt32Builder, UInt64Array, BooleanArray,
 };
 use arrow::compute;
 use arrow::datatypes::{Field, Schema, SchemaBuilder, UInt32Type, UInt64Type};
@@ -1169,11 +1169,10 @@ pub(crate) fn apply_join_filter_to_indices(
     probe_indices: UInt32Array,
     filter: &JoinFilter,
     build_side: JoinSide,
-) -> Result<(UInt64Array, UInt32Array)> {
+) -> Result<(UInt64Array, UInt32Array, BooleanArray)> {
     if build_indices.is_empty() && probe_indices.is_empty() {
-        return Ok((build_indices, probe_indices));
+        return Ok((build_indices, probe_indices, BooleanArray::from(vec![false])));
     };
-
     let intermediate_batch = build_batch_from_indices(
         filter.schema(),
         build_input_buffer,
@@ -1194,6 +1193,7 @@ pub(crate) fn apply_join_filter_to_indices(
     Ok((
         downcast_array(left_filtered.as_ref()),
         downcast_array(right_filtered.as_ref()),
+        mask.clone(),
     ))
 }
 

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -36,9 +36,10 @@ use crate::execution_plan::CardinalityEffect;
 use crate::joins::utils::{ColumnIndex, JoinFilter};
 use crate::{ColumnStatistics, DisplayFormatType, ExecutionPlan, PhysicalExpr};
 
+use arrow::array::SymbolicExpr;
 use arrow::datatypes::{Field, Schema, SchemaRef};
-use datafusion_common::scalar::ScalarValue;
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use datafusion_common::scalar::ScalarValue;
 use datafusion_common::stats::Precision;
 use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
@@ -247,10 +248,8 @@ impl ExecutionPlan for ProjectionExec {
                 if alias.to_lowercase() == "__slt__pos__" {
                     if let Some(x) = expr.as_any().downcast_ref::<Literal>() {
                         match x.value() {
-                                ScalarValue::Decimal128(Some(i), _, _) => {
-                                    Some(*i as usize)
-                                }
-                                _ => panic!("Unsupported literal: {:?}", x),
+                            ScalarValue::Decimal128(Some(i), _, _) => Some(*i as usize),
+                            _ => panic!("Unsupported literal: {:?}", x),
                         }
                     } else {
                         None
@@ -379,13 +378,33 @@ impl ProjectionStream {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        let row_symbolic_data = self.table_name.as_ref().map(|tbl| {
+            (0..batch.num_rows())
+                .map(|i| SymbolicExpr::row(tbl.clone(), self.row_offset.unwrap_or(0) + i))
+                .collect::<Vec<_>>()
+        });
+
+        dbg!(&batch.row_symbolic_data());
+        dbg!(&row_symbolic_data);
+
         if arrays.is_empty() {
             let options =
                 RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-            RecordBatch::try_new_with_options(Arc::clone(&self.schema), arrays, &options)
-                .map_err(Into::into)
+            RecordBatch::try_new_with_options_and_constraints_and_symbolic_data(
+                Arc::clone(&self.schema),
+                arrays,
+                &options,
+                row_symbolic_data,
+                None,
+            )
+            .map_err(Into::into)
         } else {
-            RecordBatch::try_new(Arc::clone(&self.schema), arrays).map_err(Into::into)
+            RecordBatch::try_new_with_symbolic_data(
+                Arc::clone(&self.schema),
+                arrays,
+                row_symbolic_data,
+            )
+            .map_err(Into::into)
         }
     }
 }

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -37,6 +37,7 @@ use crate::joins::utils::{ColumnIndex, JoinFilter};
 use crate::{ColumnStatistics, DisplayFormatType, ExecutionPlan, PhysicalExpr};
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
+use datafusion_common::scalar::ScalarValue;
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion_common::stats::Precision;
 use datafusion_common::tree_node::{
@@ -238,8 +239,33 @@ impl ExecutionPlan for ProjectionExec {
             None
         };
 
+        // check if upstream is a ProjectionExec with the special column __slt__pos__
+        let row_offset = if let Some(projection) =
+            self.input.as_any().downcast_ref::<ProjectionExec>()
+        {
+            projection.expr.iter().find_map(|(expr, alias)| {
+                if alias.to_lowercase() == "__slt__pos__" {
+                    if let Some(x) = expr.as_any().downcast_ref::<Literal>() {
+                        match x.value() {
+                                ScalarValue::Decimal128(Some(i), _, _) => {
+                                    Some(*i as usize)
+                                }
+                                _ => panic!("Unsupported literal: {:?}", x),
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        };
+
         Ok(Box::pin(ProjectionStream {
             table_name,
+            row_offset,
             schema: Arc::clone(&self.schema),
             expr: self.expr.iter().map(|x| Arc::clone(&x.0)).collect(),
             input: self.input.execute(partition, context)?,
@@ -345,6 +371,7 @@ impl ProjectionStream {
                 expr.evaluate(batch).and_then(|v| {
                     v.into_maybe_symbolic_array(
                         batch.num_rows(),
+                        self.row_offset.unwrap_or(0),
                         self.table_name.clone(),
                         idx,
                     )
@@ -366,6 +393,7 @@ impl ProjectionStream {
 /// Projection iterator
 struct ProjectionStream {
     table_name: Option<String>,
+    row_offset: Option<usize>,
     schema: SchemaRef,
     expr: Vec<Arc<dyn PhysicalExpr>>,
     input: SendableRecordBatchStream,

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -46,6 +46,7 @@ use datafusion_common::tree_node::{
 };
 use datafusion_common::{internal_err, JoinSide, Result};
 use datafusion_execution::TaskContext;
+use datafusion_expr::ColumnarValue;
 use datafusion_physical_expr::equivalence::ProjectionMapping;
 use datafusion_physical_expr::utils::collect_columns;
 use datafusion_physical_expr::PhysicalExprRef;
@@ -368,41 +369,59 @@ impl ProjectionStream {
             .enumerate()
             .map(|(idx, expr)| {
                 expr.evaluate(batch).and_then(|v| {
-                    v.into_maybe_symbolic_array(
-                        batch.num_rows(),
-                        self.row_offset.unwrap_or(0),
-                        self.table_name.clone(),
-                        idx,
-                    )
+                    if self.table_name.is_some() {
+                        v.into_maybe_symbolic_array(
+                            batch.num_rows(),
+                            self.row_offset.unwrap_or(0),
+                            self.table_name.clone(),
+                            idx,
+                        )
+                    } else if batch.constraints().is_some() {
+                        // dbg!(&v);
+                        match v {
+                            ColumnarValue::Array(array) => {
+                                let array_clone = Arc::clone(&array);
+                                Ok(array_clone.with_symbolic_data(
+                                    &batch.column(idx).to_symbolic_data(),
+                                ))
+                            }
+                            _ => panic!("Unsupported columnar value: {:?}", v),
+                        }
+                    } else {
+                        v.into_array(batch.num_rows())
+                    }
                 })
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let row_symbolic_data = self.table_name.as_ref().map(|tbl| {
-            (0..batch.num_rows())
-                .map(|i| SymbolicExpr::row(tbl.clone(), self.row_offset.unwrap_or(0) + i))
-                .collect::<Vec<_>>()
-        });
+        // dbg!(&batch.row_symbolic_data());
+        // dbg!(&row_symbolic_data);
 
-        dbg!(&batch.row_symbolic_data());
-        dbg!(&row_symbolic_data);
+        let mut constraints = None;
+        if let Some(c) = batch.constraints() {
+            constraints = Some(c.clone());
+        } else {
+            if let Some(table_name) = self.table_name.clone() {
+                let symbolic_expr = SymbolicExpr::generic_row(table_name, None);
+                constraints = Some(symbolic_expr);
+            }
+        }
 
         if arrays.is_empty() {
             let options =
                 RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-            RecordBatch::try_new_with_options_and_constraints_and_symbolic_data(
+            RecordBatch::try_new_with_options_and_constraints(
                 Arc::clone(&self.schema),
                 arrays,
                 &options,
-                row_symbolic_data,
-                None,
+                constraints,
             )
             .map_err(Into::into)
         } else {
-            RecordBatch::try_new_with_symbolic_data(
+            RecordBatch::try_new_with_constraints(
                 Arc::clone(&self.schema),
                 arrays,
-                row_symbolic_data,
+                constraints,
             )
             .map_err(Into::into)
         }


### PR DESCRIPTION
This pull request merges the latest **five** commits on **`aditya/sym_eval`**  into `michael/sym-eval`.

| SHA&nbsp;&nbsp; | Commit message |
|-----------------|----------------|
| **1274649** | *Add symbolic evaluation of nested loop joins* |
| **c275ed8** | *Form per-row symbolic `IN LIST` binary expressions*|
| **a3f4f4a** | *Initial symbolic-evaluation support for `IN LIST`* |
| **3375c24** | *Add `row_offset` to `SymbolicExpr::Variable` for UNIONs*  |
| **12248de** | *Remove stray `dbg!` prints* |

---

